### PR TITLE
Add calendar CRUD operations and session management

### DIFF
--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -154,7 +154,7 @@ export default function PlanDetailPage() {
     end.setHours(eh, em, 0, 0)
 
     try {
-      const created = await createSession({
+      await createSession({
         user_id: user.id,
         plan_id: planId,
         subject_id: Number(createSubjectId),
@@ -163,7 +163,6 @@ export default function PlanDetailPage() {
         status: 'planned',
         notes: createNotes || null,
       })
-      const [full] = await getSessionsForPlan(planId)
       setSessions(await getSessionsForPlan(planId))
       setIsCreateOpen(false)
       toast({ title: 'Sessão criada com sucesso' })

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -179,10 +179,8 @@ export default function PlanDetailPage() {
   }) => {
     if (!editingSession) return
     try {
-      const updated = await updateSession(editingSession.id, updates)
-      setSessions((prev) =>
-        prev.map((s) => (s.id === updated.id ? { ...s, ...updated } : s)),
-      )
+      await updateSession(editingSession.id, updates)
+      setSessions(await getSessionsForPlan(planId))
       setIsEditOpen(false)
       toast({ title: 'Sessão atualizada' })
     } catch (e) {

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -1,12 +1,15 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import {
   ChevronLeft,
   ChevronRight,
   Calendar as CalendarIcon,
   Download,
-  RefreshCw,
   Share2,
+  Trash2,
+  Pencil,
+  CheckCircle2,
+  CircleSlash2,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
@@ -18,17 +21,32 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   getSessionsForPlan,
   updateSessionStatus,
   StudySession,
+  createSession,
+  updateSession,
+  deleteSession,
 } from '@/services/sessions'
 import { getPlanById } from '@/services/plans'
 import { useNotificationsContext } from '@/contexts/NotificationsContext'
+import { useAuthContext } from '@/contexts/AuthContext'
 import { Skeleton } from '@/components/ui/skeleton'
 import { generateICS } from '@/lib/ics'
 import { toast } from '@/components/ui/use-toast'
 import { SharePlanDialog } from '@/components/SharePlanDialog'
+import { getSubjects } from '@/services/subjects'
+import { endOfDay, isWithinInterval, startOfDay } from 'date-fns'
 
 const timeSlots = Array.from(
   { length: 16 },
@@ -38,35 +56,50 @@ const timeSlots = Array.from(
 export default function PlanDetailPage() {
   const { id } = useParams()
   const { updateSessionAndNotification } = useNotificationsContext()
+  const { user } = useAuthContext()
   const [sessions, setSessions] = useState<StudySession[]>([])
   const [planTitle, setPlanTitle] = useState('')
+  const [sessionDuration, setSessionDuration] = useState<number>(60)
   const [loading, setLoading] = useState(true)
   const [currentWeek, setCurrentWeek] = useState(new Date())
+  const [subjects, setSubjects] = useState<{ id: number; name: string }[]>([])
+  const [editingSession, setEditingSession] = useState<StudySession | null>(null)
+  const [isEditOpen, setIsEditOpen] = useState(false)
+  const [isCreateOpen, setIsCreateOpen] = useState(false)
+  const [createDate, setCreateDate] = useState<Date | null>(null)
+  const [createSubjectId, setCreateSubjectId] = useState<string>('')
+  const [createStart, setCreateStart] = useState<string>('07:00')
+  const [createEnd, setCreateEnd] = useState<string>('08:00')
+  const [createNotes, setCreateNotes] = useState<string>('')
   const planId = Number(id)
+  const dayColumnRefs = useRef<(HTMLDivElement | null)[]>([])
 
   useEffect(() => {
-    const fetchSessions = async () => {
-      if (!id) return
+    const fetchData = async () => {
+      if (!id || !user) return
       setLoading(true)
       try {
-        const [planData, sessionsData] = await Promise.all([
+        const [planData, sessionsData, subs] = await Promise.all([
           getPlanById(planId),
           getSessionsForPlan(planId),
+          getSubjects(user.id),
         ])
         setPlanTitle(planData?.title || 'Plano de Estudo')
+        if (planData?.session_duration) setSessionDuration(planData.session_duration)
         setSessions(sessionsData)
+        setSubjects(subs.map((s: any) => ({ id: s.id, name: s.name })))
       } catch (error) {
         toast({
           variant: 'destructive',
           title: 'Erro',
-          description: 'Não foi possível carregar as sessões do plano.',
+          description: 'Não foi possível carregar dados do plano/calendário.',
         })
       } finally {
         setLoading(false)
       }
     }
-    fetchSessions()
-  }, [id, planId])
+    fetchData()
+  }, [id, planId, user])
 
   const getWeekDays = (date: Date) => {
     const start = new Date(date)
@@ -84,12 +117,90 @@ export default function PlanDetailPage() {
 
   const handleStatusUpdate = async (
     sessionId: number,
-    status: 'done' | 'skipped',
+    status: 'planned' | 'done' | 'skipped',
   ) => {
     await updateSessionStatus(sessionId, status)
     setSessions((prev) =>
       prev.map((s) => (s.id === sessionId ? { ...s, status } : s)),
     )
+  }
+
+  const openCreateAtPosition = (day: Date, y: number, container: HTMLDivElement) => {
+    const rect = container.getBoundingClientRect()
+    const ratio = Math.min(Math.max((y - rect.top) / rect.height, 0), 1)
+    const totalMinutes = 16 * 60
+    const minutesFromStart = Math.round((ratio * totalMinutes) / 15) * 15
+    const startHour = 7 + Math.floor(minutesFromStart / 60)
+    const startMinute = minutesFromStart % 60
+    const start = new Date(day)
+    start.setHours(startHour, startMinute, 0, 0)
+    const end = new Date(start.getTime() + sessionDuration * 60000)
+
+    setCreateDate(day)
+    setCreateStart(`${start.getHours().toString().padStart(2, '0')}:${start.getMinutes().toString().padStart(2, '0')}`)
+    setCreateEnd(`${end.getHours().toString().padStart(2, '0')}:${end.getMinutes().toString().padStart(2, '0')}`)
+    setCreateSubjectId(subjects[0]?.id ? String(subjects[0].id) : '')
+    setCreateNotes('')
+    setIsCreateOpen(true)
+  }
+
+  const handleCreateSession = async () => {
+    if (!user || !createDate || !createSubjectId) return
+    const [sh, sm] = createStart.split(':').map(Number)
+    const [eh, em] = createEnd.split(':').map(Number)
+    const start = new Date(createDate)
+    start.setHours(sh, sm, 0, 0)
+    const end = new Date(createDate)
+    end.setHours(eh, em, 0, 0)
+
+    try {
+      const created = await createSession({
+        user_id: user.id,
+        plan_id: planId,
+        subject_id: Number(createSubjectId),
+        start_time: start.toISOString(),
+        end_time: end.toISOString(),
+        status: 'planned',
+        notes: createNotes || null,
+      })
+      const [full] = await getSessionsForPlan(planId)
+      setSessions(await getSessionsForPlan(planId))
+      setIsCreateOpen(false)
+      toast({ title: 'Sessão criada com sucesso' })
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Erro ao criar sessão' })
+    }
+  }
+
+  const handleUpdateSession = async (updates: {
+    subject_id?: number
+    start_time?: string
+    end_time?: string
+    notes?: string | null
+  }) => {
+    if (!editingSession) return
+    try {
+      const updated = await updateSession(editingSession.id, updates)
+      setSessions((prev) =>
+        prev.map((s) => (s.id === updated.id ? { ...s, ...updated } : s)),
+      )
+      setIsEditOpen(false)
+      toast({ title: 'Sessão atualizada' })
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Erro ao atualizar sessão' })
+    }
+  }
+
+  const handleDeleteSession = async () => {
+    if (!editingSession) return
+    try {
+      await deleteSession(editingSession.id)
+      setSessions((prev) => prev.filter((s) => s.id !== editingSession.id))
+      setIsEditOpen(false)
+      toast({ title: 'Sessão excluída' })
+    } catch (e) {
+      toast({ variant: 'destructive', title: 'Erro ao excluir sessão' })
+    }
   }
 
   const handleExportICS = () => {
@@ -172,7 +283,7 @@ export default function PlanDetailPage() {
           ))}
         </div>
         <div className="grid grid-cols-7">
-          {weekDays.map((day) => (
+          {weekDays.map((day, idx) => (
             <div
               key={day.toISOString()}
               className="flex flex-col border-r last:border-r-0"
@@ -183,18 +294,27 @@ export default function PlanDetailPage() {
                   day: '2-digit',
                 })}
               </div>
-              <div className="relative flex-1">
+              <div
+                className="relative flex-1"
+                ref={(el) => (dayColumnRefs.current[idx] = el)}
+                onDoubleClick={(e) => {
+                  const container = dayColumnRefs.current[idx]
+                  if (container) openCreateAtPosition(day, e.clientY, container)
+                }}
+                title="Clique duplo para adicionar sessão"
+              >
                 {timeSlots.map((time) => (
                   <div key={time} className="h-16 border-t"></div>
                 ))}
                 {sessions
-                  .filter(
-                    (s) =>
-                      new Date(s.start_time).toDateString() ===
-                      day.toDateString(),
-                  )
+                  .filter((s) => {
+                    const sd = startOfDay(day)
+                    const ed = endOfDay(day)
+                    const st = new Date(s.start_time)
+                    return isWithinInterval(st, { start: sd, end: ed })
+                  })
                   .map((session) => (
-                    <Dialog key={session.id}>
+                    <Dialog key={session.id} open={isEditOpen && editingSession?.id === session.id} onOpenChange={(o) => { setIsEditOpen(o); if (o) setEditingSession(session) }}>
                       <DialogTrigger asChild>
                         <div
                           className="absolute w-[95%] left-1/2 -translate-x-1/2 p-2 rounded-md cursor-pointer text-foreground"
@@ -240,50 +360,111 @@ export default function PlanDetailPage() {
                       </DialogTrigger>
                       <DialogContent>
                         <DialogHeader>
-                          <DialogTitle>Detalhes da Sessão</DialogTitle>
+                          <DialogTitle>Editar Sessão</DialogTitle>
                         </DialogHeader>
-                        <p>
-                          <strong>Matéria:</strong> {session.subject_name}
-                        </p>
-                        <p>
-                          <strong>Horário:</strong>{' '}
-                          {new Date(session.start_time).toLocaleTimeString(
-                            'pt-BR',
-                            {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            },
-                          )}{' '}
-                          -{' '}
-                          {new Date(session.end_time).toLocaleTimeString(
-                            'pt-BR',
-                            {
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            },
-                          )}
-                        </p>
-                        <div className="flex gap-2 mt-4">
-                          <Button
-                            onClick={() =>
-                              handleStatusUpdate(session.id, 'done')
-                            }
-                          >
-                            Marcar como Concluída
-                          </Button>
-                          <Button
-                            variant="outline"
-                            onClick={() =>
-                              handleStatusUpdate(session.id, 'skipped')
-                            }
-                          >
-                            Marcar como Pulada
-                          </Button>
+                        <div className="space-y-3">
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <Label>Matéria</Label>
+                              <Select
+                                defaultValue={String(session.subject_id)}
+                                onValueChange={(v) =>
+                                  setEditingSession({ ...session, subject_id: Number(v) } as any)
+                                }
+                              >
+                                <SelectTrigger className="mt-1">
+                                  <SelectValue placeholder="Selecione a matéria" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {subjects.map((s) => (
+                                    <SelectItem key={s.id} value={String(s.id)}>
+                                      {s.name}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                            <div>
+                              <Label>Notas</Label>
+                              <Textarea
+                                defaultValue={(session as any).notes || ''}
+                                className="mt-1"
+                                onChange={(e) =>
+                                  setEditingSession({ ...session, notes: e.target.value } as any)
+                                }
+                              />
+                            </div>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <Label>Início</Label>
+                              <Input
+                                type="time"
+                                className="mt-1"
+                                defaultValue={new Date(session.start_time)
+                                  .toLocaleTimeString('pt-BR', {
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                    hour12: false,
+                                  })}
+                                onChange={(e) => {
+                                  const [hh, mm] = e.target.value.split(':').map(Number)
+                                  const d = new Date(session.start_time)
+                                  d.setHours(hh, mm, 0, 0)
+                                  setEditingSession({ ...session, start_time: d.toISOString() } as any)
+                                }}
+                              />
+                            </div>
+                            <div>
+                              <Label>Fim</Label>
+                              <Input
+                                type="time"
+                                className="mt-1"
+                                defaultValue={new Date(session.end_time)
+                                  .toLocaleTimeString('pt-BR', {
+                                    hour: '2-digit',
+                                    minute: '2-digit',
+                                    hour12: false,
+                                  })}
+                                onChange={(e) => {
+                                  const [hh, mm] = e.target.value.split(':').map(Number)
+                                  const d = new Date(session.end_time)
+                                  d.setHours(hh, mm, 0, 0)
+                                  setEditingSession({ ...session, end_time: d.toISOString() } as any)
+                                }}
+                              />
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap gap-2 pt-2">
+                            <Button onClick={() => handleStatusUpdate(session.id, 'done')}>
+                              <CheckCircle2 className="mr-2 h-4 w-4" /> Concluída
+                            </Button>
+                            <Button variant="outline" onClick={() => handleStatusUpdate(session.id, 'skipped')}>
+                              <CircleSlash2 className="mr-2 h-4 w-4" /> Pulada
+                            </Button>
+                            <Button variant="secondary" onClick={() => handleStatusUpdate(session.id, 'planned')}>
+                              Desmarcar
+                            </Button>
+                            <div className="ml-auto flex gap-2">
+                              <Button
+                                variant="default"
+                                onClick={() =>
+                                  handleUpdateSession({
+                                    subject_id: (editingSession as any)?.subject_id ?? session.subject_id,
+                                    start_time: (editingSession as any)?.start_time ?? session.start_time,
+                                    end_time: (editingSession as any)?.end_time ?? session.end_time,
+                                    notes: (editingSession as any)?.notes ?? (session as any).notes ?? null,
+                                  })
+                                }
+                              >
+                                <Pencil className="mr-2 h-4 w-4" /> Salvar
+                              </Button>
+                              <Button variant="destructive" onClick={handleDeleteSession}>
+                                <Trash2 className="mr-2 h-4 w-4" /> Excluir
+                              </Button>
+                            </div>
+                          </div>
                         </div>
-                        <Textarea
-                          placeholder="Adicionar notas..."
-                          className="mt-4"
-                        />
                       </DialogContent>
                     </Dialog>
                   ))}
@@ -291,6 +472,49 @@ export default function PlanDetailPage() {
             </div>
           ))}
         </div>
+
+        {/* Criar sessão */}
+        <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Nova Sessão</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-3">
+              <div>
+                <Label>Matéria</Label>
+                <Select value={createSubjectId} onValueChange={setCreateSubjectId}>
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder="Selecione a matéria" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {subjects.map((s) => (
+                      <SelectItem key={s.id} value={String(s.id)}>
+                        {s.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label>Início</Label>
+                  <Input type="time" className="mt-1" value={createStart} onChange={(e) => setCreateStart(e.target.value)} />
+                </div>
+                <div>
+                  <Label>Fim</Label>
+                  <Input type="time" className="mt-1" value={createEnd} onChange={(e) => setCreateEnd(e.target.value)} />
+                </div>
+              </div>
+              <div>
+                <Label>Notas</Label>
+                <Textarea className="mt-1" value={createNotes} onChange={(e) => setCreateNotes(e.target.value)} />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button onClick={handleCreateSession}>Criar</Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
       </div>
     </div>
   )

--- a/src/pages/PlanDetail.tsx
+++ b/src/pages/PlanDetail.tsx
@@ -63,7 +63,9 @@ export default function PlanDetailPage() {
   const [loading, setLoading] = useState(true)
   const [currentWeek, setCurrentWeek] = useState(new Date())
   const [subjects, setSubjects] = useState<{ id: number; name: string }[]>([])
-  const [editingSession, setEditingSession] = useState<StudySession | null>(null)
+  const [editingSession, setEditingSession] = useState<StudySession | null>(
+    null,
+  )
   const [isEditOpen, setIsEditOpen] = useState(false)
   const [isCreateOpen, setIsCreateOpen] = useState(false)
   const [createDate, setCreateDate] = useState<Date | null>(null)
@@ -85,7 +87,8 @@ export default function PlanDetailPage() {
           getSubjects(user.id),
         ])
         setPlanTitle(planData?.title || 'Plano de Estudo')
-        if (planData?.session_duration) setSessionDuration(planData.session_duration)
+        if (planData?.session_duration)
+          setSessionDuration(planData.session_duration)
         setSessions(sessionsData)
         setSubjects(subs.map((s: any) => ({ id: s.id, name: s.name })))
       } catch (error) {
@@ -125,7 +128,11 @@ export default function PlanDetailPage() {
     )
   }
 
-  const openCreateAtPosition = (day: Date, y: number, container: HTMLDivElement) => {
+  const openCreateAtPosition = (
+    day: Date,
+    y: number,
+    container: HTMLDivElement,
+  ) => {
     const rect = container.getBoundingClientRect()
     const ratio = Math.min(Math.max((y - rect.top) / rect.height, 0), 1)
     const totalMinutes = 16 * 60
@@ -137,8 +144,12 @@ export default function PlanDetailPage() {
     const end = new Date(start.getTime() + sessionDuration * 60000)
 
     setCreateDate(day)
-    setCreateStart(`${start.getHours().toString().padStart(2, '0')}:${start.getMinutes().toString().padStart(2, '0')}`)
-    setCreateEnd(`${end.getHours().toString().padStart(2, '0')}:${end.getMinutes().toString().padStart(2, '0')}`)
+    setCreateStart(
+      `${start.getHours().toString().padStart(2, '0')}:${start.getMinutes().toString().padStart(2, '0')}`,
+    )
+    setCreateEnd(
+      `${end.getHours().toString().padStart(2, '0')}:${end.getMinutes().toString().padStart(2, '0')}`,
+    )
     setCreateSubjectId(subjects[0]?.id ? String(subjects[0].id) : '')
     setCreateNotes('')
     setIsCreateOpen(true)
@@ -311,7 +322,14 @@ export default function PlanDetailPage() {
                     return isWithinInterval(st, { start: sd, end: ed })
                   })
                   .map((session) => (
-                    <Dialog key={session.id} open={isEditOpen && editingSession?.id === session.id} onOpenChange={(o) => { setIsEditOpen(o); if (o) setEditingSession(session) }}>
+                    <Dialog
+                      key={session.id}
+                      open={isEditOpen && editingSession?.id === session.id}
+                      onOpenChange={(o) => {
+                        setIsEditOpen(o)
+                        if (o) setEditingSession(session)
+                      }}
+                    >
                       <DialogTrigger asChild>
                         <div
                           className="absolute w-[95%] left-1/2 -translate-x-1/2 p-2 rounded-md cursor-pointer text-foreground"
@@ -366,7 +384,10 @@ export default function PlanDetailPage() {
                               <Select
                                 defaultValue={String(session.subject_id)}
                                 onValueChange={(v) =>
-                                  setEditingSession({ ...session, subject_id: Number(v) } as any)
+                                  setEditingSession({
+                                    ...session,
+                                    subject_id: Number(v),
+                                  } as any)
                                 }
                               >
                                 <SelectTrigger className="mt-1">
@@ -387,7 +408,10 @@ export default function PlanDetailPage() {
                                 defaultValue={(session as any).notes || ''}
                                 className="mt-1"
                                 onChange={(e) =>
-                                  setEditingSession({ ...session, notes: e.target.value } as any)
+                                  setEditingSession({
+                                    ...session,
+                                    notes: e.target.value,
+                                  } as any)
                                 }
                               />
                             </div>
@@ -398,17 +422,23 @@ export default function PlanDetailPage() {
                               <Input
                                 type="time"
                                 className="mt-1"
-                                defaultValue={new Date(session.start_time)
-                                  .toLocaleTimeString('pt-BR', {
-                                    hour: '2-digit',
-                                    minute: '2-digit',
-                                    hour12: false,
-                                  })}
+                                defaultValue={new Date(
+                                  session.start_time,
+                                ).toLocaleTimeString('pt-BR', {
+                                  hour: '2-digit',
+                                  minute: '2-digit',
+                                  hour12: false,
+                                })}
                                 onChange={(e) => {
-                                  const [hh, mm] = e.target.value.split(':').map(Number)
+                                  const [hh, mm] = e.target.value
+                                    .split(':')
+                                    .map(Number)
                                   const d = new Date(session.start_time)
                                   d.setHours(hh, mm, 0, 0)
-                                  setEditingSession({ ...session, start_time: d.toISOString() } as any)
+                                  setEditingSession({
+                                    ...session,
+                                    start_time: d.toISOString(),
+                                  } as any)
                                 }}
                               />
                             </div>
@@ -417,29 +447,50 @@ export default function PlanDetailPage() {
                               <Input
                                 type="time"
                                 className="mt-1"
-                                defaultValue={new Date(session.end_time)
-                                  .toLocaleTimeString('pt-BR', {
-                                    hour: '2-digit',
-                                    minute: '2-digit',
-                                    hour12: false,
-                                  })}
+                                defaultValue={new Date(
+                                  session.end_time,
+                                ).toLocaleTimeString('pt-BR', {
+                                  hour: '2-digit',
+                                  minute: '2-digit',
+                                  hour12: false,
+                                })}
                                 onChange={(e) => {
-                                  const [hh, mm] = e.target.value.split(':').map(Number)
+                                  const [hh, mm] = e.target.value
+                                    .split(':')
+                                    .map(Number)
                                   const d = new Date(session.end_time)
                                   d.setHours(hh, mm, 0, 0)
-                                  setEditingSession({ ...session, end_time: d.toISOString() } as any)
+                                  setEditingSession({
+                                    ...session,
+                                    end_time: d.toISOString(),
+                                  } as any)
                                 }}
                               />
                             </div>
                           </div>
                           <div className="flex flex-wrap gap-2 pt-2">
-                            <Button onClick={() => handleStatusUpdate(session.id, 'done')}>
-                              <CheckCircle2 className="mr-2 h-4 w-4" /> Concluída
+                            <Button
+                              onClick={() =>
+                                handleStatusUpdate(session.id, 'done')
+                              }
+                            >
+                              <CheckCircle2 className="mr-2 h-4 w-4" />{' '}
+                              Concluída
                             </Button>
-                            <Button variant="outline" onClick={() => handleStatusUpdate(session.id, 'skipped')}>
+                            <Button
+                              variant="outline"
+                              onClick={() =>
+                                handleStatusUpdate(session.id, 'skipped')
+                              }
+                            >
                               <CircleSlash2 className="mr-2 h-4 w-4" /> Pulada
                             </Button>
-                            <Button variant="secondary" onClick={() => handleStatusUpdate(session.id, 'planned')}>
+                            <Button
+                              variant="secondary"
+                              onClick={() =>
+                                handleStatusUpdate(session.id, 'planned')
+                              }
+                            >
                               Desmarcar
                             </Button>
                             <div className="ml-auto flex gap-2">
@@ -447,16 +498,28 @@ export default function PlanDetailPage() {
                                 variant="default"
                                 onClick={() =>
                                   handleUpdateSession({
-                                    subject_id: (editingSession as any)?.subject_id ?? session.subject_id,
-                                    start_time: (editingSession as any)?.start_time ?? session.start_time,
-                                    end_time: (editingSession as any)?.end_time ?? session.end_time,
-                                    notes: (editingSession as any)?.notes ?? (session as any).notes ?? null,
+                                    subject_id:
+                                      (editingSession as any)?.subject_id ??
+                                      session.subject_id,
+                                    start_time:
+                                      (editingSession as any)?.start_time ??
+                                      session.start_time,
+                                    end_time:
+                                      (editingSession as any)?.end_time ??
+                                      session.end_time,
+                                    notes:
+                                      (editingSession as any)?.notes ??
+                                      (session as any).notes ??
+                                      null,
                                   })
                                 }
                               >
                                 <Pencil className="mr-2 h-4 w-4" /> Salvar
                               </Button>
-                              <Button variant="destructive" onClick={handleDeleteSession}>
+                              <Button
+                                variant="destructive"
+                                onClick={handleDeleteSession}
+                              >
                                 <Trash2 className="mr-2 h-4 w-4" /> Excluir
                               </Button>
                             </div>
@@ -479,7 +542,10 @@ export default function PlanDetailPage() {
             <div className="space-y-3">
               <div>
                 <Label>Matéria</Label>
-                <Select value={createSubjectId} onValueChange={setCreateSubjectId}>
+                <Select
+                  value={createSubjectId}
+                  onValueChange={setCreateSubjectId}
+                >
                   <SelectTrigger className="mt-1">
                     <SelectValue placeholder="Selecione a matéria" />
                   </SelectTrigger>
@@ -495,16 +561,30 @@ export default function PlanDetailPage() {
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <Label>Início</Label>
-                  <Input type="time" className="mt-1" value={createStart} onChange={(e) => setCreateStart(e.target.value)} />
+                  <Input
+                    type="time"
+                    className="mt-1"
+                    value={createStart}
+                    onChange={(e) => setCreateStart(e.target.value)}
+                  />
                 </div>
                 <div>
                   <Label>Fim</Label>
-                  <Input type="time" className="mt-1" value={createEnd} onChange={(e) => setCreateEnd(e.target.value)} />
+                  <Input
+                    type="time"
+                    className="mt-1"
+                    value={createEnd}
+                    onChange={(e) => setCreateEnd(e.target.value)}
+                  />
                 </div>
               </div>
               <div>
                 <Label>Notas</Label>
-                <Textarea className="mt-1" value={createNotes} onChange={(e) => setCreateNotes(e.target.value)} />
+                <Textarea
+                  className="mt-1"
+                  value={createNotes}
+                  onChange={(e) => setCreateNotes(e.target.value)}
+                />
               </div>
               <div className="flex justify-end gap-2">
                 <Button onClick={handleCreateSession}>Criar</Button>

--- a/src/services/sessions.ts
+++ b/src/services/sessions.ts
@@ -2,8 +2,10 @@ import { supabase } from '@/lib/supabase/client'
 import { Tables } from './db'
 
 export type StudySession = Tables<'study_sessions'> & {
-  subject: string
-  planTitle: string
+  subject?: string
+  subject_name?: string
+  subject_color?: string
+  planTitle?: string
 }
 
 export const getSessionsForPlan = async (
@@ -27,16 +29,62 @@ export const getSessionsForPlan = async (
     throw error
   }
 
-  return data.map((session) => ({
+  return (data || []).map((session: any) => ({
     ...session,
-    subject_name: session.subjects.name,
-    subject_color: session.subjects.color,
+    subject_name: session.subjects?.name,
+    subject_color: session.subjects?.color,
   }))
+}
+
+export const createSession = async (
+  payload: Tables<'study_sessions'>['Insert'],
+): Promise<Tables<'study_sessions'>> => {
+  const { data, error } = await supabase
+    .from('study_sessions')
+    .insert(payload)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Error creating session:', error)
+    throw error
+  }
+  return data
+}
+
+export const updateSession = async (
+  sessionId: number,
+  updates: Tables<'study_sessions'>['Update'],
+): Promise<Tables<'study_sessions'>> => {
+  const { data, error } = await supabase
+    .from('study_sessions')
+    .update(updates)
+    .eq('id', sessionId)
+    .select()
+    .single()
+
+  if (error) {
+    console.error('Error updating session:', error)
+    throw error
+  }
+  return data
+}
+
+export const deleteSession = async (sessionId: number): Promise<void> => {
+  const { error } = await supabase
+    .from('study_sessions')
+    .delete()
+    .eq('id', sessionId)
+
+  if (error) {
+    console.error('Error deleting session:', error)
+    throw error
+  }
 }
 
 export const updateSessionStatus = async (
   sessionId: number,
-  status: 'done' | 'skipped',
+  status: 'planned' | 'done' | 'skipped',
 ): Promise<Tables<'study_sessions'>> => {
   const { data, error } = await supabase
     .from('study_sessions')


### PR DESCRIPTION
## Purpose

The user requested enhanced calendar functionality to display more than just days and times. They wanted the ability to add, edit, and delete study sessions directly within the calendar interface, as well as mark sessions as completed or uncompleted to track study hours.

## Code changes

- **Enhanced session display**: Added subject names, colors, and notes to calendar sessions
- **CRUD operations**: Implemented create, update, and delete functions for study sessions
- **Interactive calendar**: Added double-click to create sessions at specific times
- **Session management**: Added buttons to mark sessions as completed, skipped, or planned
- **Edit dialog**: Created comprehensive edit interface with time pickers and subject selection
- **Create dialog**: Added new session creation with subject selection and time inputs
- **Service layer**: Extended session services with `createSession`, `updateSession`, and `deleteSession` functions
- **Status updates**: Enhanced status management to include 'planned', 'done', and 'skipped' states
- **UI improvements**: Added proper form controls, labels, and validation for session managementTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d918fd8f62f142cbbd6aead92b4c54e4/pixel-garden)

👀 [Preview Link](https://d918fd8f62f142cbbd6aead92b4c54e4-pixel-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d918fd8f62f142cbbd6aead92b4c54e4</projectId>-->
<!--<branchName>pixel-garden</branchName>-->